### PR TITLE
silence warnings in pancakes.swift

### DIFF
--- a/playgrounds/pancakes.playground/Sources/Ontology.swift
+++ b/playgrounds/pancakes.playground/Sources/Ontology.swift
@@ -24,7 +24,8 @@ public enum his {
   public static let appetite: Void = ()
   public enum favourite { public static let kind: Bool = true }
 }
-public enum growing { public typealias back = Void }
+public enum growing { public typealias back = _back }
+public protocol _back {}
 
 public enum he { public static func asked(for: Void?) -> Int { 0 } }
 public enum making {
@@ -67,7 +68,7 @@ public func aliens(with: Void) -> asd {
 public enum you { public static let know: Bool = true }
 public enum these { public static let days: Bool = true }
 public enum hospitals { public enum and { public static let all: Bool = true }}
-public typealias back = Void
+public protocol back {}
 extension Bool: ExpressibleByIntegerLiteral {
   public init(integerLiteral value: Int) { self.init(false) }
 }


### PR DESCRIPTION
Hi! A friend just shared your tweet for this with me and I was eager to check out the actual code—that dynamic callable was pretty clever; couldn't work that part out just from looking at it. I did, however, notice that your two `is` checks emit warnings that they never fail, so I figured I'd PR a little something to change that :)